### PR TITLE
Add Clear Input button and adjust styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,9 +60,24 @@ h1, h2 {
   font-size: 16px;
   transition: background-color 0.3s ease;
 }
+/* Button container */
+.button-container {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+#clearBtn {
+  background-color: #e74c3c;
+}
 
-.button:hover {
-  background-color: #2980b9;
+#clearBtn:hover {
+  background-color: #c0392b;
+}
+/* Responsive design */
+@media (max-width: 600px) {
+  .button-container {
+    flex-direction: column;
+  }
 }
 
 /* Output section */
@@ -85,6 +100,7 @@ h1, h2 {
 .hidden {
   display: none !important;
 }
+
 
 /* Print styles */
 @media print {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,13 @@
         <option value="colorful">Colorful</option>
       </select>
     </div>
-    <button id="generateBtn" class="button">Generate Image</button>
+    
+    <div class="button-container">
+      <button id="generateBtn" class="button">Generate Image</button>
+      <!-- Clear input button added -->
+      <button id="clearBtn" class="button">Clear Input</button>
+    </div>
+  
   </section>
 
   <section id="output-section" class="section">

--- a/js/app.js
+++ b/js/app.js
@@ -3,10 +3,18 @@ document.addEventListener('DOMContentLoaded', (event) => {
   const markdownInput = document.getElementById('markdownInput');
   const themeSelect = document.getElementById('themeSelect');
   const copyImageBtn = document.getElementById('copyImageBtn');
+  const clearBtn = document.getElementById('clearBtn'); 
 
   generateBtn.addEventListener('click', generateImage);
   copyImageBtn.addEventListener('click', copyImageToClipboard);
+  clearBtn.addEventListener('click', clearAllInput);
 });
+
+function clearAllInput() {
+  document.getElementById('markdownInput').value = '';
+  document.getElementById('themeSelect').value = 'default'; // Reset to default
+  clearCanvas();
+}
 
 function generateImage(){
   const markdown = document.getElementById('markdownInput').value;


### PR DESCRIPTION
This pull request adds a **"Clear Input"** button. The button is positioned next to the "Generate Image" button and clears the Markdown input field when clicked.

### Changes include:

**HTML:**

Added a "Clear Input" button next to the "Generate Image" button in the input section.
**CSS:**

Added styling for the "Clear Input" button and Adjusted the button's width and responsiveness to ensure proper display on different screen sizes.

**JavaScript:**

**Implemented functionality to clear the Markdown input field when the "Clear Input" button is clicked.**

**Testing:**

Verified that the "Clear Input" button correctly clears the Markdown input field.
Checked responsiveness and visual consistency with **Generate Image buttons**.
![image](https://github.com/user-attachments/assets/d8398e33-e550-4f3d-af7d-4805ad92ecaa)
