### PR TITLE
Add global box-sizing: border-box rule

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 /* Base styles */
 html {
   color: #222;
@@ -25,7 +29,9 @@ textarea {
 }
 
 /* Layout elements */
-header, main, footer {
+header,
+main,
+footer {
   background-color: #fff;
   padding: 20px;
   margin-bottom: 20px;
@@ -33,7 +39,8 @@ header, main, footer {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
-h1, h2 {
+h1,
+h2 {
   color: #2c3e50;
 }
 
@@ -101,7 +108,6 @@ h1, h2 {
   display: none !important;
 }
 
-
 /* Print styles */
 @media print {
   *,
@@ -121,7 +127,8 @@ h1, h2 {
     overflow: visible;
   }
 
-  #downloadLink, .theme-selector {
+  #downloadLink,
+  .theme-selector {
     display: none;
   }
 }
@@ -132,7 +139,9 @@ h1, h2 {
     padding: 10px;
   }
 
-  header, main, footer {
+  header,
+  main,
+  footer {
     padding: 10px;
   }
 }


### PR DESCRIPTION
This pull request adds a global box-sizing: border-box; rule to all elements, ensuring more predictable element sizing by including padding and borders within the total width and height of elements.

### Before
![image](https://github.com/user-attachments/assets/4e839741-6cd4-425f-9ce0-533f8cb915db)

### After
![image](https://github.com/user-attachments/assets/b0e5b784-42a3-44d3-8418-556caf389654)
