### PR TITLE
Add code to toggle output section visibility and manage hidden div

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -88,6 +88,10 @@ h2 {
 }
 
 /* Output section */
+#output-section {
+  display: none;
+}
+
 #canvasContainer {
   overflow-x: auto;
   margin-bottom: 20px;

--- a/js/app.js
+++ b/js/app.js
@@ -19,6 +19,10 @@ function clearAllInput() {
 function generateImage(){
   const markdown = document.getElementById('markdownInput').value;
   const theme = document.getElementById('themeSelect').value;
+  
+  document.getElementById('output-section').style.display = 'block';
+  const canvasContainer = document.getElementById('canvasContainer');
+
 
   if (!markdown.trim()) {
     clearCanvas();
@@ -33,15 +37,14 @@ function generateImage(){
   hiddenDiv.innerHTML = htmlTable;
   hiddenDiv.className = `table-theme-${theme}`;
   hiddenDiv.style.padding = '20px';
-  document.body.appendChild(hiddenDiv);
+  canvasContainer.appendChild(hiddenDiv);
 
   // Use html2canvas to convert the div to a canvas
   html2canvas(hiddenDiv, { useCORS: true }).then(canvas => {
     // Remove the hidden div
-    document.body.removeChild(hiddenDiv);
+    canvasContainer.removeChild(hiddenDiv);
 
     // Display the canvas and enable download/copy
-    const canvasContainer = document.getElementById('canvasContainer');
     canvasContainer.innerHTML = '';
     canvasContainer.appendChild(canvas);
     enableDownload(canvas);


### PR DESCRIPTION
This pull request includes the following changes:

- Added a CSS rule to hide the #output-section by default.
- Added JavaScript code to display the #output-section when necessary and manage the hiddenDiv within the canvasContainer.

### Before
![image](https://github.com/user-attachments/assets/c9fbe11f-fdfb-4998-a3a5-094ca504595a)

### After
![image](https://github.com/user-attachments/assets/81d87529-7997-49cc-9c7b-c35e6631e156)

